### PR TITLE
use direct connection for mongo check_fm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,10 @@ prerelease:
 	git add pyproject.toml
 	git commit -m "Release version $$(poetry version --short)"
 	git tag $$(poetry version --short)
+
+.PHONY: preminor
+preminor:
+	poetry version preminor
+	git add pyproject.toml
+	git commit -m "Release version $$(poetry version --short)"
+	git tag $$(poetry version --short)

--- a/src/pytest_mock_resources/container/mongo.py
+++ b/src/pytest_mock_resources/container/mongo.py
@@ -47,7 +47,7 @@ class MongoConfig(DockerContainerConfig):
 
     def check_fn(self):
         try:
-            client = pymongo.MongoClient(self.host, self.port)
+            client = pymongo.MongoClient(self.host, self.port, directConnection=True)
             db = client[self.root_database]
             db.command("ismaster")
         except pymongo.errors.ConnectionFailure:


### PR DESCRIPTION
Switch to passing `directConnection=True` because for replication, the container will be up before the replication set initialization is done.  